### PR TITLE
BxBlockArrays are handled in the BxRebuild

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 [![Build status](https://ci.appveyor.com/api/projects/status/qhmposba71n8lvpo/branch/master?svg=true)](https://ci.appveyor.com/project/icarus-consulting/brix/branch/master)
 [![codecov](https://codecov.io/gh/icarus-consulting/BriX/branch/master/graph/badge.svg?token=4SZ8XXKXDU)](https://codecov.io/gh/icarus-consulting/BriX)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
@@ -216,8 +217,9 @@ Every Block must have a name:
 
 //C#
 var brix =
-    new BxBlock("root", //name must be specified.
-	new BxProp("branch", "My Branch")
+    new BxBlock(
+        "root", //name must be specified.
+	    new BxProp("branch", "My Branch")
     );
 ```
 
@@ -231,8 +233,8 @@ The same is the case for arrays:
 //Xml
 <shopping-list>
     <fruits>
-	<fruit>Apple</fruit>
-	<fruit>Banana</fruit>		
+    	<fruit>Apple</fruit>
+    	<fruit>Banana</fruit>		
     </fruits>
 </shopping-list>
 
@@ -240,22 +242,98 @@ The same is the case for arrays:
 {
     "fruits":
     [
-        "Apple", "Banana"
+        "Apple",
+        "Banana"
     ]
 }
 
 //C#
 var list =
     new BxBlock("shopping-list",
-	new BxArray("fruits", "fruit", //"fruit" as name for entries must be specified
-	    "Apple", "Banana"
+    	new BxArray("fruits", "fruit", //"fruit" as name for entries must be specified
+    	    "Apple", 
+    	    "Banana"
+        )
+    );
+```
+
+### Complex Arrays
+And for complex arrays:
+```
+//Xml
+<shopping-list>
+	<fruits>
+		<fruit>
+			<name>Apple</name>
+			<weight>500</weight>
+		</fruit>
+		<fruit>
+			<name>Banana</name>
+			<weight>300</weight>
+		</fruit>
+	</fruits>
+</shopping-list>
+
+
+//Json
+{
+	"fruits": [
+		{
+			"name": "Apple",
+			"weight": "500"
+		},
+		{
+			"name": "Banana",
+			"weight": "300"
+		}
+	]
+}
+
+//C#
+var list =
+    new BxBlock("shopping-list",
+	    new BxBlockArray("fruits", "fruit", //"fruit" as name for entries must be specified
+	        new BxBlock(
+	            new BxProp("name", "Apple"), 
+	            new BxProp("weight", "500")
+            ), 
+            new BxBlock(
+                new BxProp("name", "Banana"), 
+                new BxProp("weight", "300")
+            )
         )
     );
 ```
 
 ### Xml Attributes
 Json does not support attributes, so they are not included in BriX objects. If you need them, you might implement or extend the JsonMedia interface to support them and write BriX objects.
+### BxMap
+Easy way for adding mutiple Props by KeyValuePairs. Note: no duplicated keys are allowed!
+```
+//xml
+<person>
+    <name>George</name>
+    <age>23</age>
+    <gender>male</gender>
+</person>
 
+//json
+{
+    "name": "George",
+    "age": "23",
+    "gender": "male"
+}
+
+//C#
+new BxBlock(
+    "person",
+    new BxMap(
+        "name", "George",
+        "age", "23",
+        "gender", "male"
+    )
+)
+```
 ## Conditional BriX
 Instead of using large if/else constructs:
 
@@ -269,3 +347,27 @@ new BxBlock("Todos",
     )
 )
 ```
+
+## Rebuildable Brix
+For sending a BriX e.g. as a response of a request, it´s possible to print a BriX to a RebuildMedia. 
+
+```csharp
+    var response =
+        new BxBlock("Weather Report",
+    	    new BxBlock(
+	        new BxProp("Temperature", () => weatherServer.Degrees("Berlin").AsDouble())
+	    )
+    );
+
+report.Print(new RebuildMedia());
+return report.Content(); // the byte[] of the BriX as xml 
+```
+
+At the requesting side, you can reconstruct the BriX with BxRebuilt
+```csharp
+var brix = response.Body()
+var rebuildedBrix = new BxRebuild(brix);
+```
+
+
+

--- a/src/BriX/BxBlockArray.cs
+++ b/src/BriX/BxBlockArray.cs
@@ -23,7 +23,7 @@
 using System.Collections.Generic;
 using Yaapii.Atoms.Enumerable;
 
-namespace BriX.Media
+namespace BriX
 {
     /// <summary>
     /// A list of blocks.

--- a/src/BriX/BxRebuilt.cs
+++ b/src/BriX/BxRebuilt.cs
@@ -77,7 +77,7 @@ namespace BriX
                 {
                     result = isRoot ? builtNode.Document.Root : builtNode as XElement;
                 }
-                else if(builtNode.NodeType == System.Xml.XmlNodeType.Document)
+                else if (builtNode.NodeType == System.Xml.XmlNodeType.Document)
                 {
                     result = (builtNode as XDocument).Root;
                 }
@@ -110,12 +110,24 @@ namespace BriX
                     new BxConditional(
                         () => data.Value().Attribute("bx-type").Value == "array",
                         () =>
-                        new BxArray(data.Value().Name.LocalName, data.Value().Attribute("bx-array-item-name").Value,
-                            new Mapped<XElement, string>(
-                                elem => elem.Value,
-                                data.Value().Elements()
+                        new Ternary<XNode, IBrix>(
+                            new LengthOf(data.Value().Elements()).Value() > 0 &&
+                            new LengthOf(
+                                new FirstOf<XElement>(data.Value().Elements()).Value().Attributes()
+                            ).Value() > 0,
+                            new BxBlockArray(data.Value().Name.LocalName, data.Value().Attribute("bx-array-item-name").Value,
+                                new Mapped<XNode, IBrix>(
+                                    elem => new BxRebuilt(elem, false),
+                                    data.Value().Elements()
+                                )
+                            ),
+                            new BxArray(data.Value().Name.LocalName, data.Value().Attribute("bx-array-item-name").Value,
+                                new Mapped<XElement, string>(
+                                    elem => elem.Value,
+                                    data.Value().Elements()
+                                )
                             )
-                        )
+                        ).Value()
                     ),
                     new BxConditional(
                         () => data.Value().Attribute("bx-type").Value == "prop",

--- a/tests/Test.BriX/BxRebuiltTests.cs
+++ b/tests/Test.BriX/BxRebuiltTests.cs
@@ -22,7 +22,6 @@
 
 using BriX.Media;
 using Xunit;
-using Yaapii.Atoms.IO;
 using Yaapii.Xml;
 
 namespace BriX.Test
@@ -95,13 +94,13 @@ namespace BriX.Test
             Assert.Equal(
                 1,
                 new XMLCursor(
-                    new InputOf(
+                    new BxRebuilt(
                         new BxBlock("root",
                             new BxBlockArray("items", "item",
                                 new BxBlock(new BxProp("name", "I-Tem"))
                             )
                         ).Print(new RebuildMedia())
-                    )
+                    ).Print(new XmlMedia())
                 ).Nodes("/root/items/item[name/text() = 'I-Tem']")
                 .Count
             );
@@ -113,11 +112,11 @@ namespace BriX.Test
             Assert.Equal(
                 1,
                 new XMLCursor(
-                    new InputOf(
+                    new BxRebuilt(
                         new BxBlock("root",
                             new BxProp("of", "all evil")
                         ).Print(new RebuildMedia())
-                    )
+                    ).Print(new XmlMedia())
                 ).Nodes("/root/of[text() = 'all evil']")
                 .Count
             );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
<!-- Describe the current behavior or link to a open issue -->
closes #10 
closes #11 
### What is the new behavior?
<!-- Describe the new behavior -->

### Does this PR introduce a breaking change? (check one with "x")
- [x] Yes
- [ ] No
Namespace of the BxBlockArray has changed from BriX.Media to BriX
### If this PR contains a breaking change, please describe the impact and migration path for existing applications
Migration is changing the Namespace of BriX.Media for BxBlockArrays to Brix
Most likely the namespace is already referenced, because BxBlockArrays are almost never used alone
###  Other information